### PR TITLE
Changed from .AppImage to .deb

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "productName": "MCLC",
   "name": "mclc",
   "description": "Lightweight, open-source Minecraft launcher (Electron + React) - features profile & modpack management, skin preview, Discord Rich Presence, and a modern UI for easy installs and updates.",
-  "author": "Fernsehheft",
+  "author": "Fernsehheft <contact@pluginhub.de>",
   "version": "1.5.2",
   "main": "electron/main.js",
   "scripts": {
@@ -43,7 +43,7 @@
     },
     "linux": {
       "target": [
-        "AppImage"
+        "deb"
       ],
       "category": "Game"
     }


### PR DESCRIPTION
Changed from .AppImage to .deb for compatibility for the website.

**If you add it to the website, specify that it only works on system based on Debian/Ubuntu !**